### PR TITLE
fix: add missing parens for mysql custom indexes

### DIFF
--- a/static/rdbm/mysql_index.json
+++ b/static/rdbm/mysql_index.json
@@ -2,9 +2,9 @@
   "jansPerson": {
     "fields": [],
     "custom": [
-      "CAST(address->'$.v' AS CHAR(48) ARRAY)",
-      "lower(`uid`)",
-      "lower(`mail`)"
+      "(CAST(address->'$.v' AS CHAR(48) ARRAY))",
+      "(lower(`uid`))",
+      "(lower(`mail`))"
     ]
   },
   "jansClnt": {


### PR DESCRIPTION
The removal of parenthesis introduced in https://github.com/JanssenProject/jans-setup/commit/1913acabc6327bb9b08438248286f0d62de8d45b causes MySQL syntax error when creating functional indexes, i.e. `CAST(col_name)`, `lower(col_name)`. This PR adds those missing parenthesis.